### PR TITLE
优化radio_button的点击范围

### DIFF
--- a/lib/src/components/radio/brn_checkbox.dart
+++ b/lib/src/components/radio/brn_checkbox.dart
@@ -40,7 +40,7 @@ class BrnCheckbox extends StatefulWidget {
   /// 默认值MainAxisSize.min
   final MainAxisSize mainAxisSize;
 
-  /// 默认值HitTestBehavior.deferToChild控制widget.onRadioItemClick触发的点击范围
+  /// 默认值HitTestBehavior.translucent控制widget.onRadioItemClick触发的点击范围
   final HitTestBehavior behavior;
 
   const BrnCheckbox({
@@ -54,7 +54,7 @@ class BrnCheckbox extends StatefulWidget {
     this.childOnRight = true,
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.mainAxisSize = MainAxisSize.min,
-    this.behavior=HitTestBehavior.deferToChild
+    this.behavior=HitTestBehavior.translucent
   });
 
   @override

--- a/lib/src/components/radio/brn_checkbox.dart
+++ b/lib/src/components/radio/brn_checkbox.dart
@@ -40,6 +40,9 @@ class BrnCheckbox extends StatefulWidget {
   /// 默认值MainAxisSize.min
   final MainAxisSize mainAxisSize;
 
+  /// 默认值HitTestBehavior.deferToChild控制widget.onRadioItemClick触发的点击范围
+  final HitTestBehavior behavior;
+
   const BrnCheckbox({
     Key key,
     @required this.radioIndex,
@@ -51,6 +54,7 @@ class BrnCheckbox extends StatefulWidget {
     this.childOnRight = true,
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.mainAxisSize = MainAxisSize.min,
+    this.behavior=HitTestBehavior.deferToChild
   });
 
   @override
@@ -92,6 +96,7 @@ class BrnCheckboxState extends State<BrnCheckbox> {
         });
         widget.onValueChangedAtIndex(widget.radioIndex, _isSelected);
       },
+      behavior: widget.behavior,
     );
   }
 }

--- a/lib/src/components/radio/brn_checkbox.dart
+++ b/lib/src/components/radio/brn_checkbox.dart
@@ -43,19 +43,18 @@ class BrnCheckbox extends StatefulWidget {
   /// 默认值HitTestBehavior.translucent控制widget.onRadioItemClick触发的点击范围
   final HitTestBehavior behavior;
 
-  const BrnCheckbox({
-    Key key,
-    @required this.radioIndex,
-    @required this.onValueChangedAtIndex,
-    this.disable = false,
-    this.isSelected = false,
-    this.iconPadding,
-    this.child,
-    this.childOnRight = true,
-    this.mainAxisAlignment = MainAxisAlignment.start,
-    this.mainAxisSize = MainAxisSize.min,
-    this.behavior=HitTestBehavior.translucent
-  });
+  const BrnCheckbox(
+      {Key key,
+      @required this.radioIndex,
+      @required this.onValueChangedAtIndex,
+      this.disable = false,
+      this.isSelected = false,
+      this.iconPadding,
+      this.child,
+      this.childOnRight = true,
+      this.mainAxisAlignment = MainAxisAlignment.start,
+      this.mainAxisSize = MainAxisSize.min,
+      this.behavior = HitTestBehavior.translucent});
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/src/components/radio/brn_radio_button.dart
+++ b/lib/src/components/radio/brn_radio_button.dart
@@ -40,7 +40,7 @@ class BrnRadioButton extends StatelessWidget {
   /// 默认值MainAxisSize.min
   final MainAxisSize mainAxisSize;
 
-  /// 默认值HitTestBehavior.deferToChild控制widget.onRadioItemClick触发的点击范围
+  /// 默认值HitTestBehavior.translucent控制widget.onRadioItemClick触发的点击范围
   final HitTestBehavior behavior;
 
   const BrnRadioButton({
@@ -54,7 +54,7 @@ class BrnRadioButton extends StatelessWidget {
     this.childOnRight = true,
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.mainAxisSize = MainAxisSize.min,
-    this.behavior=HitTestBehavior.deferToChild
+    this.behavior=HitTestBehavior.translucent
   });
 
   @override

--- a/lib/src/components/radio/brn_radio_button.dart
+++ b/lib/src/components/radio/brn_radio_button.dart
@@ -40,6 +40,9 @@ class BrnRadioButton extends StatelessWidget {
   /// 默认值MainAxisSize.min
   final MainAxisSize mainAxisSize;
 
+  /// 默认值HitTestBehavior.deferToChild控制widget.onRadioItemClick触发的点击范围
+  final HitTestBehavior behavior;
+
   const BrnRadioButton({
     Key key,
     @required this.radioIndex,
@@ -51,6 +54,7 @@ class BrnRadioButton extends StatelessWidget {
     this.childOnRight = true,
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.mainAxisSize = MainAxisSize.min,
+    this.behavior=HitTestBehavior.deferToChild
   });
 
   @override
@@ -74,6 +78,7 @@ class BrnRadioButton extends StatelessWidget {
       onRadioItemClick: () {
         onValueChangedAtIndex(radioIndex, true);
       },
+      behavior: behavior,
     );
   }
 }

--- a/lib/src/components/radio/brn_radio_button.dart
+++ b/lib/src/components/radio/brn_radio_button.dart
@@ -43,19 +43,18 @@ class BrnRadioButton extends StatelessWidget {
   /// 默认值HitTestBehavior.translucent控制widget.onRadioItemClick触发的点击范围
   final HitTestBehavior behavior;
 
-  const BrnRadioButton({
-    Key key,
-    @required this.radioIndex,
-    @required this.onValueChangedAtIndex,
-    this.disable = false,
-    this.isSelected = false,
-    this.iconPadding,
-    this.child,
-    this.childOnRight = true,
-    this.mainAxisAlignment = MainAxisAlignment.start,
-    this.mainAxisSize = MainAxisSize.min,
-    this.behavior=HitTestBehavior.translucent
-  });
+  const BrnRadioButton(
+      {Key key,
+      @required this.radioIndex,
+      @required this.onValueChangedAtIndex,
+      this.disable = false,
+      this.isSelected = false,
+      this.iconPadding,
+      this.child,
+      this.childOnRight = true,
+      this.mainAxisAlignment = MainAxisAlignment.start,
+      this.mainAxisSize = MainAxisSize.min,
+      this.behavior = HitTestBehavior.translucent});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/components/radio/brn_radio_core.dart
+++ b/lib/src/components/radio/brn_radio_core.dart
@@ -68,7 +68,7 @@ class BrnRadioCore extends StatefulWidget {
       this.disSelectedImage,
       this.disUnselectedImage,
       this.onRadioItemClick,
-      this.behavior=HitTestBehavior.translucent})
+      this.behavior = HitTestBehavior.translucent})
       : super(key: key);
 
   @override

--- a/lib/src/components/radio/brn_radio_core.dart
+++ b/lib/src/components/radio/brn_radio_core.dart
@@ -50,7 +50,7 @@ class BrnRadioCore extends StatefulWidget {
 
   final VoidCallback onRadioItemClick;
 
-  /// 默认值HitTestBehavior.deferToChild控制widget.onRadioItemClick触发的点击范围
+  /// 默认值HitTestBehavior.translucent控制widget.onRadioItemClick触发的点击范围
   final HitTestBehavior behavior;
 
   const BrnRadioCore(
@@ -68,7 +68,7 @@ class BrnRadioCore extends StatefulWidget {
       this.disSelectedImage,
       this.disUnselectedImage,
       this.onRadioItemClick,
-      this.behavior=HitTestBehavior.deferToChild})
+      this.behavior=HitTestBehavior.translucent})
       : super(key: key);
 
   @override

--- a/lib/src/components/radio/brn_radio_core.dart
+++ b/lib/src/components/radio/brn_radio_core.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
@@ -49,6 +50,9 @@ class BrnRadioCore extends StatefulWidget {
 
   final VoidCallback onRadioItemClick;
 
+  /// 默认值HitTestBehavior.deferToChild控制widget.onRadioItemClick触发的点击范围
+  final HitTestBehavior behavior;
+
   const BrnRadioCore(
       {Key key,
       @required this.radioIndex,
@@ -63,7 +67,8 @@ class BrnRadioCore extends StatefulWidget {
       this.unselectedImage,
       this.disSelectedImage,
       this.disUnselectedImage,
-      this.onRadioItemClick})
+      this.onRadioItemClick,
+      this.behavior=HitTestBehavior.deferToChild})
       : super(key: key);
 
   @override
@@ -131,7 +136,7 @@ class _BrnRadioCoreState extends State<BrnRadioCore> {
 
     return GestureDetector(
       child: radioWidget,
-      behavior: HitTestBehavior.translucent,
+      behavior: widget.behavior,
       onTap: () {
         if (widget.disable == true) return;
         widget.onRadioItemClick();


### PR DESCRIPTION
声明：非bug
先前通过**GestureDetector**来触发点击事件 固定**behavior**为**HitTestBehavior.translucent**，导致**radio_button**空白处也会触发点击事件 。
可能出现交互问题的场景：使用**Column**或竖直方向的**ListView** 如果有一个**BrnCheckbox**或**BrnRadioButton**内容特别长，其他的内容特别短。那大部分空白处都会触发点击事件
修改：**BrnRadioCore**新增**behavior**属性默认为**HitTestBehavior.deferToChild** 可配置