### PR TITLE
migrate brn_loading to null safety

### DIFF
--- a/lib/src/components/loading/brn_loading.dart
+++ b/lib/src/components/loading/brn_loading.dart
@@ -1,7 +1,5 @@
+import 'package:bruno/src/constants/brn_strings_constants.dart';
 import 'package:flutter/material.dart';
-
-/// 加载组件默认的加载文案
-const String kLoadingContent = '加载中...';
 
 /// 页面或者弹窗中间的圆形加载框，左侧是可定制的加载文案[content]，比如：加载中、提交中等等
 ///
@@ -32,7 +30,7 @@ const String kLoadingContent = '加载中...';
 class BrnPageLoading extends StatelessWidget {
   final String content;
 
-  const BrnPageLoading({this.content = kLoadingContent});
+  const BrnPageLoading({this.content = BrnStrings.loadingContent});
 
   @override
   Widget build(BuildContext context) {
@@ -79,7 +77,7 @@ class BrnLoadingDialog extends Dialog {
   /// 加载时的提示文案，默认为 `加载中...`
   final String content;
 
-  const BrnLoadingDialog({Key? key, this.content = kLoadingContent})
+  const BrnLoadingDialog({Key? key, this.content = BrnStrings.loadingContent})
       : super(key: key);
 
   @override
@@ -96,7 +94,7 @@ class BrnLoadingDialog extends Dialog {
   ///    rootNavigator，详见 [showDialog] 中的 [useRootNavigator]。
   static Future<T?> show<T>(
     BuildContext context, {
-    String content = kLoadingContent,
+    String content = BrnStrings.loadingContent,
     bool barrierDismissible = true,
     bool useRootNavigator = true,
   }) {

--- a/lib/src/components/loading/brn_loading.dart
+++ b/lib/src/components/loading/brn_loading.dart
@@ -1,6 +1,7 @@
-// @dart=2.9
-
 import 'package:flutter/material.dart';
+
+/// 加载组件默认的加载文案
+const String kLoadingContent = '加载中...';
 
 /// 页面或者弹窗中间的圆形加载框，左侧是可定制的加载文案[content]，比如：加载中、提交中等等
 ///
@@ -31,7 +32,7 @@ import 'package:flutter/material.dart';
 class BrnPageLoading extends StatelessWidget {
   final String content;
 
-  BrnPageLoading({this.content});
+  const BrnPageLoading({this.content = kLoadingContent});
 
   @override
   Widget build(BuildContext context) {
@@ -40,9 +41,7 @@ class BrnPageLoading extends StatelessWidget {
         height: 50,
         width: 130,
         decoration: BoxDecoration(
-            color: Color(0xff222222),
-            border: null,
-            borderRadius: BorderRadius.circular(5)),
+            color: Color(0xff222222), borderRadius: BorderRadius.circular(5)),
         child: Center(
           child: Row(
             mainAxisSize: MainAxisSize.min,
@@ -58,7 +57,7 @@ class BrnPageLoading extends StatelessWidget {
               Container(
                 margin: EdgeInsets.only(left: 8),
                 child: Text(
-                  content ?? "加载中...",
+                  content,
                   style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
@@ -80,7 +79,8 @@ class BrnLoadingDialog extends Dialog {
   /// 加载时的提示文案，默认为 `加载中...`
   final String content;
 
-  BrnLoadingDialog({Key key, this.content = "加载中..."}) : super(key: key);
+  const BrnLoadingDialog({Key? key, this.content = kLoadingContent})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -94,13 +94,13 @@ class BrnLoadingDialog extends Dialog {
   ///  * [barrierDismissible] 点击蒙层背景是否关闭弹窗，默认为 true，可关闭，详见 [showDialog] 中的 [barrierDismissible]
   ///  * [useRootNavigator] 把弹窗添加到 [context] 中的 rootNavigator 还是最近的 [Navigator]，默认为 true，添加到
   ///    rootNavigator，详见 [showDialog] 中的 [useRootNavigator]。
-  static void show(
+  static Future<T?> show<T>(
     BuildContext context, {
-    String content,
+    String content = kLoadingContent,
     bool barrierDismissible = true,
     bool useRootNavigator = true,
   }) {
-    showDialog(
+    return showDialog<T>(
         context: context,
         barrierDismissible: barrierDismissible,
         useRootNavigator: useRootNavigator,
@@ -112,7 +112,7 @@ class BrnLoadingDialog extends Dialog {
   /// 关闭弹窗。
   ///
   ///  * [context] 上下文。
-  static void dismiss(BuildContext context) {
-    Navigator.pop(context);
+  static void dismiss<T extends Object?>(BuildContext context, [T? result]) {
+    Navigator.pop(context, result);
   }
 }

--- a/lib/src/constants/brn_strings_constants.dart
+++ b/lib/src/constants/brn_strings_constants.dart
@@ -9,4 +9,5 @@ class BrnStrings {
   static const String noData = "暂无数据";
   static const String noSearchData = "暂无搜索结果";
   static const String clickPageRetry = "请点击页面重试";
+  static const String loadingContent = '加载中...';
 }


### PR DESCRIPTION
* [x] tested on example.
* [x] feat: same behavior like showDialog which can pass value using `BrnLoadingDialog.dismiss(context)`