### PR TITLE
Null safe calendar

### DIFF
--- a/example/lib/sample/components/calendar/calendarview_example.dart
+++ b/example/lib/sample/components/calendar/calendarview_example.dart
@@ -58,69 +58,66 @@ class TagViewExamplePageState extends State<CalendarViewExample> {
   }
 
   Widget _calendarViewWeekNocontroll(context) {
-    return BrnCalendarView(
+    return BrnCalendarView.single(
       displayMode: DisplayMode.Week,
-      selectMode: SelectMode.SINGLE,
       showControllerBar: false,
-      startEndDateChange: (startDate, endDate) {
-        BrnToast.show('开始时间： $startDate , 结束时间：$endDate', context);
+      dateChange: (date) {
+        BrnToast.show('选中的时间： $date', context);
       },
     );
   }
 
   Widget _calendarViewWeekNocontrollCustomWeekName(context) {
-    return BrnCalendarView(
+    return BrnCalendarView.single(
       displayMode: DisplayMode.Week,
-      selectMode: SelectMode.SINGLE,
       showControllerBar: false,
       weekNames: ['星期天', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'],
-      startEndDateChange: (startDate, endDate) {
-        BrnToast.show('开始时间： $startDate , 结束时间：$endDate', context);
+      dateChange: (date) {
+        BrnToast.show('选中的时间： $date', context);
       },
     );
   }
 
   Widget _calendarViewWeek(context) {
-    return BrnCalendarView(
+    return BrnCalendarView.single(
       displayMode: DisplayMode.Week,
       initDisplayDate: DateTime.parse('2020-06-01'),
       minDate: DateTime(2020),
       maxDate: DateTime(2021),
-      startEndDateChange: (startDate, endDate) {
-        BrnToast.show('开始时间： $startDate , 结束时间：$endDate', context);
+      dateChange: (date) {
+        BrnToast.show('选中的时间： $date', context);
       },
     );
   }
 
   Widget _calendarViewWeekRange(context) {
-    return BrnCalendarView(
+    return BrnCalendarView.range(
       displayMode: DisplayMode.Week,
-      selectMode: SelectMode.RANGE,
-      startEndDateChange: (startDate, endDate) {
-        BrnToast.show('开始时间： $startDate , 结束时间：$endDate', context);
+      rangeDateChange: (rangeDate) {
+        BrnToast.show(
+            '开始时间： ${rangeDate.start} , 结束时间：${rangeDate.end}', context);
       },
     );
   }
 
   Widget _calendarViewMonth(context) {
-    return BrnCalendarView(
-      selectMode: SelectMode.SINGLE,
+    return BrnCalendarView.single(
       initDisplayDate: DateTime.parse('2020-06-01'),
       minDate: DateTime(2020),
       maxDate: DateTime(2021),
-      startEndDateChange: (startDate, endDate) {
-        BrnToast.show('开始时间： $startDate , 结束时间：$endDate', context);
+      dateChange: (date) {
+        BrnToast.show('选中的时间： $date', context);
       },
     );
   }
 
   Widget _calendarViewMonthRange(context) {
-    return BrnCalendarView(
-      selectMode: SelectMode.RANGE,
+    return BrnCalendarView.range(
       minDate: DateTime(2020),
       maxDate: DateTime(2023),
-      startEndDateChange: (startDate, endDate) {
-        BrnToast.show('开始时间： $startDate , 结束时间：$endDate', context);
+      rangeDateChange: (rangeDate) {
+        BrnToast.show(
+            '开始时间： ${rangeDate.start} , 结束时间：${rangeDate.end}', context);
       },
     );
   }

--- a/lib/src/components/calendar/brn_calendar_view.dart
+++ b/lib/src/components/calendar/brn_calendar_view.dart
@@ -74,7 +74,7 @@ class BrnCalendarView extends StatefulWidget {
 class _CustomCalendarViewState extends State<BrnCalendarView> {
   List<DateTime> dateList = <DateTime>[];
   late DateTime _currentDate;
-  DisplayMode? _displayMode;
+  late DisplayMode _displayMode;
   late DateTime _minDate, _maxDate;
   DateTime? _currentStartSelectedDate, _currentEndSelectedDate;
 

--- a/lib/src/components/calendar/brn_calendar_view.dart
+++ b/lib/src/components/calendar/brn_calendar_view.dart
@@ -1,6 +1,3 @@
-// @dart=2.9
-
-import 'package:bruno/bruno.dart';
 import 'package:bruno/src/constants/brn_asset_constants.dart';
 import 'package:bruno/src/theme/brn_theme_configurator.dart';
 import 'package:bruno/src/utils/brn_tools.dart';
@@ -20,7 +17,7 @@ const List<String> _defaultWeekNames = ['日', '一', '二', '三', '四', '五'
 /// 2、日历组件支持时间范围展示，仅展示范围内的日历视图，范围外日期置灰不可点击。日期范围边界后不可再翻页。
 class BrnCalendarView extends StatefulWidget {
   const BrnCalendarView(
-      {Key key,
+      {Key? key,
       this.selectMode = SelectMode.SINGLE,
       this.displayMode = DisplayMode.Month,
       this.weekNames = _defaultWeekNames,
@@ -28,10 +25,10 @@ class BrnCalendarView extends StatefulWidget {
       this.initStartSelectedDate,
       this.initEndSelectedDate,
       this.initDisplayDate,
-      this.startEndDateChange,
+      required this.startEndDateChange,
       this.minDate,
       this.maxDate})
-      : assert(weekNames != null && weekNames.length > 0),
+      : assert(weekNames.length == 7),
         super(key: key);
 
   /// 展示模式， Week, Month
@@ -41,16 +38,20 @@ class BrnCalendarView extends StatefulWidget {
   final SelectMode selectMode;
 
   /// 日历日期选择范围最小值
-  final DateTime minDate;
+  ///
+  /// 默认 `DateTime(1970)`
+  final DateTime? minDate;
 
   /// 日历日期选择范围最大值
-  final DateTime maxDate;
+  ///
+  /// 默认 `DateTime(2100)`
+  final DateTime? maxDate;
 
   /// 日历日期初始选中最小值
-  final DateTime initStartSelectedDate;
+  final DateTime? initStartSelectedDate;
 
   /// 日历日期初始选中最大值
-  final DateTime initEndSelectedDate;
+  final DateTime? initEndSelectedDate;
 
   /// 是否展示顶部控制按钮
   final bool showControllerBar;
@@ -59,9 +60,11 @@ class BrnCalendarView extends StatefulWidget {
   final List<String> weekNames;
 
   /// 初始展示月份
-  final DateTime initDisplayDate;
+  ///
+  /// 默认当前时间
+  final DateTime? initDisplayDate;
 
-  final Function(DateTime startSelectedDate, DateTime endSelectedDate)
+  final Function(DateTime? startSelectedDate, DateTime? endSelectedDate)
       startEndDateChange;
 
   @override
@@ -70,12 +73,10 @@ class BrnCalendarView extends StatefulWidget {
 
 class _CustomCalendarViewState extends State<BrnCalendarView> {
   List<DateTime> dateList = <DateTime>[];
-  DateTime _currentDate;
-  DisplayMode _displayMode;
-  DateTime _minDate,
-      _maxDate,
-      _currentStartSelectedDate,
-      _currentEndSelectedDate;
+  late DateTime _currentDate;
+  DisplayMode? _displayMode;
+  late DateTime _minDate, _maxDate;
+  DateTime? _currentStartSelectedDate, _currentEndSelectedDate;
 
   @override
   void initState() {
@@ -94,14 +95,9 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
     super.initState();
   }
 
-  @override
-  void dispose() {
-    super.dispose();
-  }
-
   void _setListOfWeekDate(DateTime weekDate) {
     dateList.clear();
-    List<DateTime> tmpDateList = List();
+    List<DateTime> tmpDateList = [];
     int previousDay = weekDate.weekday % 7;
     for (int i = 0; i < weekDate.weekday; i++) {
       tmpDateList.add(weekDate.subtract(Duration(days: previousDay - i)));
@@ -116,7 +112,7 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
 
   void _setListOfMonthDate(DateTime monthDate) {
     dateList.clear();
-    List<DateTime> tmpDateList = List();
+    List<DateTime> tmpDateList = [];
     final DateTime newDate = DateTime(monthDate.year, monthDate.month, 0);
     int previousMonthDay = (newDate.weekday + 1) % 7;
     for (int i = 1; i <= previousMonthDay; i++) {
@@ -217,8 +213,7 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
                 color: Colors.transparent,
                 padding: EdgeInsets.only(right: 15),
                 child: isNextIconEnable
-                    ? BrunoTools.getAssetImage(
-                        BrnAsset.iconCalendarNextMonth)
+                    ? BrunoTools.getAssetImage(BrnAsset.iconCalendarNextMonth)
                     : BrunoTools.getAssetImageWithColor(
                         BrnAsset.iconCalendarNextMonth, Color(0xFFCCCCCC)),
                 alignment: Alignment.center,
@@ -228,10 +223,7 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
         ),
       );
     }
-    return Container(
-      height: 0,
-      width: 0,
-    );
+    return SizedBox.shrink();
   }
 
   bool _isIconEnable(bool isPre) {
@@ -409,7 +401,7 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
                           }
                         },
                         child: Padding(
-                          padding: const EdgeInsets.all(0),
+                          padding: EdgeInsets.zero,
                           child: Container(
                             child: Center(
                               child: Text(
@@ -493,8 +485,8 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
 
   bool _getIsInRange(DateTime date) {
     if (_currentStartSelectedDate != null && _currentEndSelectedDate != null) {
-      if (date.isAfter(_currentStartSelectedDate) &&
-          date.isBefore(_currentEndSelectedDate)) {
+      if (date.isAfter(_currentStartSelectedDate!) &&
+          date.isBefore(_currentEndSelectedDate!)) {
         return true;
       } else {
         return false;
@@ -506,14 +498,14 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
 
   bool _getIsItStartAndEndDate(DateTime date) {
     if (_currentStartSelectedDate != null &&
-        _currentStartSelectedDate.day == date.day &&
-        _currentStartSelectedDate.month == date.month &&
-        _currentStartSelectedDate.year == date.year) {
+        _currentStartSelectedDate!.day == date.day &&
+        _currentStartSelectedDate!.month == date.month &&
+        _currentStartSelectedDate!.year == date.year) {
       return true;
     } else if (_currentEndSelectedDate != null &&
-        _currentEndSelectedDate.day == date.day &&
-        _currentEndSelectedDate.month == date.month &&
-        _currentEndSelectedDate.year == date.year) {
+        _currentEndSelectedDate!.day == date.day &&
+        _currentEndSelectedDate!.month == date.month &&
+        _currentEndSelectedDate!.year == date.year) {
       return true;
     } else {
       return false;
@@ -522,8 +514,8 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
 
   bool _isStartDateRadius(DateTime date) {
     if (_currentStartSelectedDate != null &&
-        _currentStartSelectedDate.day == date.day &&
-        _currentStartSelectedDate.month == date.month) {
+        _currentStartSelectedDate!.day == date.day &&
+        _currentStartSelectedDate!.month == date.month) {
       return true;
     } else if (date.weekday == 7) {
       return true;
@@ -534,8 +526,8 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
 
   bool _isEndDateRadius(DateTime date) {
     if (_currentEndSelectedDate != null &&
-        _currentEndSelectedDate.day == date.day &&
-        _currentEndSelectedDate.month == date.month) {
+        _currentEndSelectedDate!.day == date.day &&
+        _currentEndSelectedDate!.month == date.month) {
       return true;
     } else if (date.weekday == 6) {
       return true;
@@ -571,15 +563,15 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
     }
 
     if (_currentStartSelectedDate != null && _currentEndSelectedDate != null) {
-      if (!_currentEndSelectedDate.isAfter(_currentStartSelectedDate)) {
-        final DateTime d = _currentStartSelectedDate;
+      if (!_currentEndSelectedDate!.isAfter(_currentStartSelectedDate!)) {
+        final DateTime? d = _currentStartSelectedDate;
         _currentStartSelectedDate = _currentEndSelectedDate;
         _currentEndSelectedDate = d;
       }
-      if (date.isBefore(_currentStartSelectedDate)) {
+      if (date.isBefore(_currentStartSelectedDate!)) {
         _currentStartSelectedDate = date;
       }
-      if (date.isAfter(_currentEndSelectedDate)) {
+      if (date.isAfter(_currentEndSelectedDate!)) {
         _currentEndSelectedDate = date;
       }
     }

--- a/lib/src/components/calendar/brn_calendar_view.dart
+++ b/lib/src/components/calendar/brn_calendar_view.dart
@@ -333,17 +333,11 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
                                         .withOpacity(0.14)
                                     : Colors.transparent)
                                 : Colors.transparent,
-                            borderRadius: BorderRadius.only(
-                              bottomLeft: _isStartDateRadius(date)
+                            borderRadius: BorderRadius.horizontal(
+                              left: _isStartDateRadius(date)
                                   ? const Radius.circular(24.0)
                                   : const Radius.circular(0.0),
-                              topLeft: _isStartDateRadius(date)
-                                  ? const Radius.circular(24.0)
-                                  : const Radius.circular(0.0),
-                              topRight: _isEndDateRadius(date)
-                                  ? const Radius.circular(24.0)
-                                  : const Radius.circular(0.0),
-                              bottomRight: _isEndDateRadius(date)
+                              right: _isEndDateRadius(date)
                                   ? const Radius.circular(24.0)
                                   : const Radius.circular(0.0),
                             ),

--- a/lib/src/components/calendar/brn_calendar_view.dart
+++ b/lib/src/components/calendar/brn_calendar_view.dart
@@ -4,6 +4,12 @@ import 'package:bruno/src/utils/brn_tools.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+///单选日期回调函数
+typedef CalendarDateChange = Function(DateTime date);
+
+///范围选择日期回调函数
+typedef CalendarRangeDateChange = Function(DateTimeRange range);
+
 /// 展示模式，周视图模式，月视图模式
 enum DisplayMode { Week, Month }
 
@@ -25,10 +31,52 @@ class BrnCalendarView extends StatefulWidget {
       this.initStartSelectedDate,
       this.initEndSelectedDate,
       this.initDisplayDate,
-      required this.startEndDateChange,
+      @Deprecated('使用BrnCalendarView.date或BrnCalendarView.rangeDate')
+          this.startEndDateChange,
+      this.dateChange,
+      this.rangeDateChange,
       this.minDate,
       this.maxDate})
       : assert(weekNames.length == 7),
+        assert(
+            selectMode == SelectMode.SINGLE && dateChange != null ||
+                selectMode == SelectMode.RANGE && rangeDateChange != null ||
+                startEndDateChange != null,
+            '必须添加日期选择的回调函数'),
+        super(key: key);
+
+  const BrnCalendarView.single(
+      {Key? key,
+      this.displayMode = DisplayMode.Month,
+      this.weekNames = _defaultWeekNames,
+      this.showControllerBar = true,
+      this.initStartSelectedDate,
+      this.initEndSelectedDate,
+      this.initDisplayDate,
+      required CalendarDateChange this.dateChange,
+      this.minDate,
+      this.maxDate})
+      : this.selectMode = SelectMode.SINGLE,
+        this.startEndDateChange = null,
+        this.rangeDateChange = null,
+        assert(weekNames.length == 7),
+        super(key: key);
+
+  const BrnCalendarView.range(
+      {Key? key,
+      this.displayMode = DisplayMode.Month,
+      this.weekNames = _defaultWeekNames,
+      this.showControllerBar = true,
+      this.initStartSelectedDate,
+      this.initEndSelectedDate,
+      this.initDisplayDate,
+      required CalendarRangeDateChange this.rangeDateChange,
+      this.minDate,
+      this.maxDate})
+      : this.selectMode = SelectMode.RANGE,
+        this.startEndDateChange = null,
+        this.dateChange = null,
+        assert(weekNames.length == 7),
         super(key: key);
 
   /// 展示模式， Week, Month
@@ -64,8 +112,13 @@ class BrnCalendarView extends StatefulWidget {
   /// 默认当前时间
   final DateTime? initDisplayDate;
 
-  final Function(DateTime? startSelectedDate, DateTime? endSelectedDate)
+  /// 选择日期回调
+  @Deprecated('使用BrnCalendarView.date或BrnCalendarView.rangeDate')
+  final Function(DateTime startSelectedDate, DateTime endSelectedDate)?
       startEndDateChange;
+
+  final CalendarDateChange? dateChange;
+  final CalendarRangeDateChange? rangeDateChange;
 
   @override
   _CustomCalendarViewState createState() => _CustomCalendarViewState();
@@ -535,8 +588,15 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
     _currentEndSelectedDate = date;
     setState(() {
       try {
-        widget.startEndDateChange(
-            _currentStartSelectedDate, _currentEndSelectedDate);
+        if (widget.startEndDateChange != null) {
+          widget.startEndDateChange!(
+            _currentStartSelectedDate!,
+            _currentEndSelectedDate!,
+          );
+        }
+        if (widget.dateChange != null) {
+          widget.dateChange!(date);
+        }
       } catch (_) {}
     });
   }
@@ -571,8 +631,16 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
     }
     setState(() {
       try {
-        widget.startEndDateChange(
-            _currentStartSelectedDate, _currentEndSelectedDate);
+        if (widget.startEndDateChange != null) {
+          widget.startEndDateChange!(
+              _currentStartSelectedDate!, _currentEndSelectedDate!);
+        }
+        if (widget.rangeDateChange != null) {
+          widget.rangeDateChange!(DateTimeRange(
+            start: _currentStartSelectedDate!,
+            end: _currentEndSelectedDate!,
+          ));
+        }
       } catch (_) {}
     });
   }

--- a/lib/src/components/calendar/brn_calendar_view.dart
+++ b/lib/src/components/calendar/brn_calendar_view.dart
@@ -564,7 +564,7 @@ class _CustomCalendarViewState extends State<BrnCalendarView> {
 
     if (_currentStartSelectedDate != null && _currentEndSelectedDate != null) {
       if (!_currentEndSelectedDate!.isAfter(_currentStartSelectedDate!)) {
-        final DateTime? d = _currentStartSelectedDate;
+        final DateTime d = _currentStartSelectedDate!;
         _currentStartSelectedDate = _currentEndSelectedDate;
         _currentEndSelectedDate = d;
       }


### PR DESCRIPTION
* 弃用`startEndDateChange`
* 单选日期
```dart
    BrnCalendarView.single(
      displayMode: DisplayMode.Week,
      showControllerBar: false,
      dateChange: (date) {
        BrnToast.show('选中的时间： $date', context);
      },
    )
```

* 范围选择日期
```dart
    BrnCalendarView.range(
      displayMode: DisplayMode.Week,
      rangeDateChange: (rangeDate) {
        BrnToast.show(
            '开始时间： ${rangeDate.start} , 结束时间：${rangeDate.end}', context);
      },
    )
```
