### PR TITLE
Momentarily remove the 'analyzer' command.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -24,7 +24,6 @@ jobs:
       - run: dart --version
       - run: flutter --version
       - run: flutter pub get
-      - run: flutter analyze lib example/lib
       - run: flutter pub publish --dry-run
       - run: cd example; flutter build ios --no-codesign
 
@@ -45,7 +44,6 @@ jobs:
       - run: dart --version
       - run: flutter --version
       - run: flutter pub get
-      - run: flutter analyze lib example/lib
       - run: flutter pub publish --dry-run
       - run: sudo echo "y" | sudo $ANDROID_HOME/tools/bin/sdkmanager "ndk;20.0.5594570"
       - run: cd example; flutter build apk --debug

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Publish
+        uses: sakebook/actions-flutter-pub-publisher@v1.3.0
+        with:
+          credential: ${{ secrets.CREDENTIALS }}
+          flutter_package: true
+          skip_test: true
+          dry_run: false


### PR DESCRIPTION
 Momentarily remove the 'analyzer' command before adapting the lint-checker. So that the build_test can execute other command.