### PR TITLE
opt: expand bottomNavigationTile click area

### DIFF
--- a/lib/src/components/tabbar/bottom/brn_bottom_tab_bar_main.dart
+++ b/lib/src/components/tabbar/bottom/brn_bottom_tab_bar_main.dart
@@ -576,6 +576,7 @@ class _BottomNavigationTile extends StatelessWidget {
     }
     return GestureDetector(
         onTap: onTap,
+        behavior: HitTestBehavior.opaque,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisAlignment: MainAxisAlignment.spaceBetween,


### PR DESCRIPTION
点击BottomNavigationTile时需要精确点击到Icon或者label,体验不佳,现扩展Tile点击区域,Tile所属区域都可以点击.