### PR TITLE
Adapt to flutter 2.10.5

### DIFF
--- a/lib/src/components/actionsheet/brn_selected_list_action_sheet.dart
+++ b/lib/src/components/actionsheet/brn_selected_list_action_sheet.dart
@@ -6,8 +6,8 @@ import 'package:bruno/src/constants/brn_asset_constants.dart';
 import 'package:bruno/src/utils/brn_tools.dart';
 import 'package:flutter/material.dart';
 
-typedef BrnItemTitleBuilder<T> = dynamic Function<T>(int index, T entity);
-typedef BrnItemDeleteCallback<T> = bool Function<T>(int deleteIdx, T deleteEntity);
+typedef BrnItemTitleBuilder<T> = dynamic Function(int index, T entity);
+typedef BrnItemDeleteCallback<T> = bool Function(int deleteIdx, T deleteEntity);
 typedef BrnListDismissCallback = void Function(bool isClosedByClearButton);
 
 
@@ -165,10 +165,10 @@ class BrnSelectedListActionSheet<T> {
     if (_overlayEntry != null) {
       return;
     }
-    BrnSelectedListActionSheetController? tempCcontroller = controller;
-    if (tempCcontroller == null) {
-      tempCcontroller = BrnSelectedListActionSheetController();
-      tempCcontroller._isHidden = false;
+    BrnSelectedListActionSheetController? tempController = controller;
+    if (tempController == null) {
+      tempController = BrnSelectedListActionSheetController();
+      tempController._isHidden = false;
     }
     _BrnActionSheetSelectedItemListContentWidget content =
         _BrnActionSheetSelectedItemListContentWidget<T>(
@@ -178,7 +178,7 @@ class BrnSelectedListActionSheet<T> {
       },
       itemTitleBuilder: this.itemTitleBuilder,
       onItemDelete: this.onItemDelete,
-      controller: tempCcontroller,
+      controller: tempController,
     );
     content._overlayState = Overlay.of(context);
     OverlayEntry overlayEntry = OverlayEntry(builder: (context) {


### PR DESCRIPTION
Fix a compile error caused by a generic definition.

the error like that:

> ../lib/src/components/actionsheet/brn_selected_list_action_sheet.dart:179:30: Error: The argument type 'dynamic Function<T>(int, T/*1*/)' can't be assigned to the parameter type 'dynamic Function(int, T/*2*/)'.
>  - 'T/*1*/' is from 'unknown'.
>  - 'T/*2*/' is from 'package:bruno/src/components/actionsheet/brn_selected_list_action_sheet.dart' ('../lib/src/components/actionsheet/brn_selected_list_action_sheet.dart').
>       itemTitleBuilder: this.itemTitleBuilder,

It looks weird, but luckily lint gave us the answer，
```dart
typedef BrnItemTitleBuilder<T> = dynamic Function<T>(int index, T entity);
```
the second T shadowed the real generic definition, just remove it.

Also fixed a typo, `tempCcontroller  `-> `tempController `

