### PR TITLE
fix flutter 3.x warning

### DIFF
--- a/lib/src/components/appraise/brn_flutter_gif_image.dart
+++ b/lib/src/components/appraise/brn_flutter_gif_image.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' as ui show Codec;
 import 'dart:ui';
 
+import 'package:bruno/src/utils/brn_ambiguate.dart';
 import 'package:flutter/widgets.dart';
 
 /// 描述: 用于加载gif图，
@@ -127,7 +128,7 @@ class GifImageState extends State<GifImage> {
       dynamic data;
       AssetBundleImageKey key = await provider.obtainKey(ImageConfiguration());
       data = await key.bundle.load(key.name);
-      ui.Codec codec = await PaintingBinding.instance!
+      ui.Codec codec = await ambiguate(PaintingBinding.instance)!
           .instantiateImageCodec(data.buffer.asUint8List());
       for (int i = 0; i < codec.frameCount; i++) {
         FrameInfo frameInfo = await codec.getNextFrame();

--- a/lib/src/components/navbar/brn_appbar.dart
+++ b/lib/src/components/navbar/brn_appbar.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:bruno/src/components/line/brn_line.dart';
 import 'package:bruno/src/theme/brn_theme_configurator.dart';
 import 'package:bruno/src/theme/configs/brn_appbar_config.dart';
+import 'package:bruno/src/utils/brn_ambiguate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -232,15 +233,16 @@ class BrnAppBar extends PreferredSize {
     } else if (brightness == Brightness.dark) {
       _defaultConfig = _defaultConfig.merge(BrnAppBarConfig.dark());
     }
-    _defaultConfig = _defaultConfig
-        .merge(BrnAppBarConfig(backgroundColor: this.backgroundColor, showDefaultBottom: this.showDefaultBottom));
+    _defaultConfig = _defaultConfig.merge(BrnAppBarConfig(
+        backgroundColor: this.backgroundColor,
+        showDefaultBottom: this.showDefaultBottom));
 
     _defaultConfig = BrnThemeConfigurator.instance
         .getConfig(configId: _defaultConfig.configId)
         .appBarConfig
         .merge(_defaultConfig);
 
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
       SystemChrome.setSystemUIOverlayStyle(_defaultConfig.systemUiOverlayStyle);
     });
     return super.build(context);

--- a/lib/src/components/navbar/brn_search_bar.dart
+++ b/lib/src/components/navbar/brn_search_bar.dart
@@ -3,6 +3,7 @@ import 'package:bruno/src/components/navbar/brn_appbar_theme.dart';
 import 'package:bruno/src/constants/brn_asset_constants.dart';
 import 'package:bruno/src/constants/brn_strings_constants.dart';
 import 'package:bruno/src/theme/brn_theme_configurator.dart';
+import 'package:bruno/src/utils/brn_ambiguate.dart';
 import 'package:bruno/src/utils/brn_tools.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -106,7 +107,7 @@ class BrnSearchAppbar extends PreferredSize {
   Size get preferredSize => Size.fromHeight(BrnAppBarTheme.appBarHeight);
 
   Widget build(BuildContext context) {
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
       SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.light);
     });
     return super.build(context);

--- a/lib/src/components/noticebar/brn_marquee_text.dart
+++ b/lib/src/components/noticebar/brn_marquee_text.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:bruno/src/utils/brn_ambiguate.dart';
 import 'package:flutter/material.dart';
 
 /// 文字跑马灯Widget
@@ -54,7 +55,7 @@ class BrnMarqueeTextState extends State<BrnMarqueeText>
   void initState() {
     super.initState();
     scroController = new ScrollController();
-    WidgetsBinding.instance?.addPostFrameCallback((callback) {
+    ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((callback) {
       var size = context.findRenderObject()!.paintBounds.size;
       widget.width = (widget.width) > 0 ? widget.width : size.width;
       widget.height = (widget.height) > 0 ? widget.height : size.height;

--- a/lib/src/components/popup/brn_measure_size.dart
+++ b/lib/src/components/popup/brn_measure_size.dart
@@ -1,3 +1,4 @@
+import 'package:bruno/src/utils/brn_ambiguate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
@@ -21,11 +22,9 @@ class MeasureSizeRenderObject extends RenderProxyBox {
     if (oldSize == newSize) return;
 
     oldSize = newSize;
-    if (WidgetsBinding.instance != null) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
-        onChange(newSize);
-      });
-    }
+    ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
+      onChange(newSize);
+    });
   }
 }
 

--- a/lib/src/components/scroll_anchor/brn_scroll_anchor_tab.dart
+++ b/lib/src/components/scroll_anchor/brn_scroll_anchor_tab.dart
@@ -1,5 +1,6 @@
 import 'package:bruno/src/components/popup/brn_measure_size.dart';
 import 'package:bruno/src/components/tabbar/normal/brn_tab_bar.dart';
+import 'package:bruno/src/utils/brn_ambiguate.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -69,7 +70,7 @@ class _BrnScrollAnchorTabWidgetState extends State<BrnAnchorTab>
 
     fillKeyList();
 
-    WidgetsBinding.instance?.addPostFrameCallback((da) {
+    ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((da) {
       fillOffset();
       _scrollController.addListener(() {
         _updateOffset();
@@ -97,7 +98,7 @@ class _BrnScrollAnchorTabWidgetState extends State<BrnAnchorTab>
     if (sub != 0) {
       _tabController = TabController(length: widget.itemCount, vsync: this);
     }
-    WidgetsBinding.instance?.addPostFrameCallback((da) {
+    ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((da) {
       fillOffset();
     });
   }

--- a/lib/src/components/selection/widget/brn_layer_more_selection_page.dart
+++ b/lib/src/components/selection/widget/brn_layer_more_selection_page.dart
@@ -6,6 +6,7 @@ import 'package:bruno/src/components/toast/brn_toast.dart';
 import 'package:bruno/src/constants/brn_asset_constants.dart';
 import 'package:bruno/src/theme/brn_theme_configurator.dart';
 import 'package:bruno/src/theme/configs/brn_selection_config.dart';
+import 'package:bruno/src/utils/brn_ambiguate.dart';
 import 'package:bruno/src/utils/brn_tools.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -46,7 +47,7 @@ class _BrnLayerMoreSelectionPageState extends State<BrnLayerMoreSelectionPage>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
       SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
     });
     _controller = AnimationController(

--- a/lib/src/utils/brn_ambiguate.dart
+++ b/lib/src/utils/brn_ambiguate.dart
@@ -1,0 +1,8 @@
+/// This allows a value of type T or T?
+/// to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become
+/// non-nullable can still be used with `!` and `?`
+/// to support older versions of the API as well.
+// refer to https://github.com/flutter/website/blob/main/src/development/tools/sdk/release-notes/release-notes-3.0.0.md#your-code
+T? ambiguate<T>(T? value) => value;


### PR DESCRIPTION
fix `binding.instance` may cause warning.
Compatible with both flutter 3.x and earlier versions.

refer: https://github.com/flutter/website/blob/main/src/development/tools/sdk/release-notes/release-notes-3.0.0.md#your-code