### PR TITLE
fix: 修复BrnStepInputFormItem更新值时设置非法的TextSelection导致光标错位的问题 Close #235

### DIFF
--- a/lib/src/components/form/items/general/brn_step_input_item.dart
+++ b/lib/src/components/form/items/general/brn_step_input_item.dart
@@ -315,7 +315,11 @@ class BrnStepInputFormItemState extends State<BrnStepInputFormItem> {
   int get _value => int.tryParse(_textEditingController.text) ?? 0;
 
   set _value(int value) {
-    _textEditingController.text = value.toString();
+    // 如果是通过代码设置TextField的值，就将光标移动到最后
+    _textEditingController.value = TextEditingValue(
+        text: value.toString(),
+        selection: TextSelection.fromPosition(
+            TextPosition(offset: value.toString().length)));
   }
 }
 
@@ -328,10 +332,11 @@ class RangeLimitedTextInputFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
     int? newNum = int.tryParse(newValue.text);
-    if(newNum == null && minValue == 0) {
-      return TextEditingValue(text: '');
+    if (newNum == null && minValue == 0) {
+      return const TextEditingValue(
+          text: '', selection: TextSelection.collapsed(offset: 0));
     } else if (newNum != null && minValue <= newNum && newNum <= maxValue) {
-      return TextEditingValue(text: newNum.toString());
+      return newValue;
     } else {
       return oldValue;
     }


### PR DESCRIPTION
【问题描述】
用户手动输入文本内容时光标偏移导致无法正常输入文本。
详见[issue#235](https://github.com/LianjiaTech/bruno/issues/235)

【问题原因】
在更新TextFiled值的时候，以及检查输入值是否在合法范围的时候，设置了非法的TextSelection

【修改内容】
在set _value()以及RangeLimitedTextInputFormatter.formatEditUpdate()的时候确保生成正确的TextSelection

【测试】
自测在以下情况正常工作：
1. 使用加减按钮操作
2. 手动在输入框文本末尾增加内容
3. 手动在输入框文本内部增加内容
4. 手动同时删除/插入多个文本