### PR TITLE
BrnSmallOutlineButton使lineColor生效

### DIFF
--- a/lib/src/components/button/brn_small_outline_button.dart
+++ b/lib/src/components/button/brn_small_outline_button.dart
@@ -118,7 +118,7 @@ class BrnSmallOutlineButton extends StatelessWidget {
           radius: defaultThemeConfig.smallButtonRadius,
           text: title,
           disableLineColor: defaultThemeConfig.commonConfig.borderColorBase,
-          lineColor: defaultThemeConfig.commonConfig.borderColorBase,
+          lineColor: lineColor ?? defaultThemeConfig.commonConfig.borderColorBase,
           textColor: textColor ?? defaultThemeConfig.commonConfig.colorTextBase,
           disableTextColor: Color(0xFFCCCCCC),
           isEnable: isEnable,


### PR DESCRIPTION
当前 BrnSmallOutlineButton 组件对外暴露属性 lineColor 不生效, 内部没有使用.
提交当前代码修复该问题