### PR TITLE
修复BrnCheckbox组件,第一次设置isSelected后,无法更新样式问题

### DIFF
--- a/lib/src/components/button/brn_small_outline_button.dart
+++ b/lib/src/components/button/brn_small_outline_button.dart
@@ -118,7 +118,7 @@ class BrnSmallOutlineButton extends StatelessWidget {
           radius: defaultThemeConfig.smallButtonRadius,
           text: title,
           disableLineColor: defaultThemeConfig.commonConfig.borderColorBase,
-          lineColor: defaultThemeConfig.commonConfig.borderColorBase,
+          lineColor: lineColor ?? defaultThemeConfig.commonConfig.borderColorBase,
           textColor: textColor ?? defaultThemeConfig.commonConfig.colorTextBase,
           disableTextColor: Color(0xFFCCCCCC),
           isEnable: isEnable,

--- a/lib/src/components/radio/brn_checkbox.dart
+++ b/lib/src/components/radio/brn_checkbox.dart
@@ -77,6 +77,12 @@ class BrnCheckboxState extends State<BrnCheckbox> {
   }
 
   @override
+  void didUpdateWidget(covariant BrnCheckbox oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _isSelected = widget.isSelected;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return BrnRadioCore(
       radioIndex: widget.radioIndex,


### PR DESCRIPTION
在使用`BrnCheckbox`组件时,对`isSelected`传值后,外部已经在 `setState`中 改变传入`isSelected`的值,但选中样式没有发生改变,该组件源码中没有在`didUpdateWidget`中更新私有`_isSelected`属性.

同样影响`BrnMultipleBottomButton`组件,使用`BrnMultipleBottomController`的`setState`方法对`selectAllState`属性进行设置失效.