### PR TITLE
opt: add missing themeData configs for brn groups.

### DIFF
--- a/lib/src/components/form/items/group/brn_normal_group.dart
+++ b/lib/src/components/form/items/group/brn_normal_group.dart
@@ -61,6 +61,7 @@ class BrnNormalFormGroup extends StatefulWidget {
     this.onRemoveTap,
     this.onTip,
     this.deleteLabel,
+    this.themeData,
     required this.children,
   }) : super(key: key) {
     this.themeData ??= BrnFormItemConfig();
@@ -86,7 +87,7 @@ class BrnNormalFormGroupState extends State<BrnNormalFormGroup> {
   Widget build(BuildContext context) {
     return Container(
       padding: EdgeInsets.only(top: 14),
-      color: Colors.white,
+      color: widget.themeData!.backgroundColor,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[

--- a/lib/src/components/form/items/group/brn_portrait_radio_group.dart
+++ b/lib/src/components/form/items/group/brn_portrait_radio_group.dart
@@ -99,7 +99,7 @@ class BrnPortraitRadioGroupState extends State<BrnPortraitRadioGroup> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Colors.white,
+      color: widget.themeData!.backgroundColor,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: getRadioList(widget.options),


### PR DESCRIPTION
This PR removes hard-coded white background and make it obeys the themeData provided by users or the global config for `BrnNormalGroup` and `BrnPortaitRadioGroup` for a better flexibility.