### PR TITLE
fix: 将View.of(context) 调用从initState移动到didChangeDependencies，修复报错

### DIFF
--- a/lib/src/components/selection/widget/brn_selection_range_widget.dart
+++ b/lib/src/components/selection/widget/brn_selection_range_widget.dart
@@ -1,4 +1,3 @@
-
 import 'package:bruno/src/components/button/brn_big_main_button.dart';
 import 'package:bruno/src/components/calendar/brn_calendar_view.dart';
 import 'package:bruno/src/components/line/brn_line.dart';
@@ -82,7 +81,7 @@ class _BrnRangeSelectionGroupWidgetState
 
   @override
   void initState() {
-    _screenWidth = View.of(context).physicalSize.width / View.of(context).devicePixelRatio;
+    super.initState();
     _initData();
     _tabController = TabController(vsync: this, length: _firstList.length);
     if (_firstIndex >= 0) {
@@ -94,7 +93,13 @@ class _BrnRangeSelectionGroupWidgetState
           ? _firstList
           : _firstList[_tabController.index].children);
     });
-    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _screenWidth =
+        View.of(context).physicalSize.width / View.of(context).devicePixelRatio;
   }
 
   @override
@@ -237,14 +242,10 @@ class _BrnRangeSelectionGroupWidgetState
 
     ///如果指定展示列，则按照指定列展示，否则动态计算宽度。最大不超过四列。
     if (widget.rowCount == null) {
-      int oneCountTagWidth =
-          (_screenWidth - 40 - 12 * (1 - 1)) ~/ 1;
-      int twoCountTagWidth =
-          (_screenWidth - 40 - 12 * (2 - 1)) ~/ 2;
-      int threeCountTagWidth =
-          (_screenWidth - 40 - 12 * (3 - 1)) ~/ 3;
-      int fourCountTagWidth =
-          (_screenWidth - 40 - 12 * (4 - 1)) ~/ 4;
+      int oneCountTagWidth = (_screenWidth - 40 - 12 * (1 - 1)) ~/ 1;
+      int twoCountTagWidth = (_screenWidth - 40 - 12 * (2 - 1)) ~/ 2;
+      int threeCountTagWidth = (_screenWidth - 40 - 12 * (3 - 1)) ~/ 3;
+      int fourCountTagWidth = (_screenWidth - 40 - 12 * (4 - 1)) ~/ 4;
       if (maxWidthSize.width > twoCountTagWidth) {
         tagWidth = oneCountTagWidth;
       } else if (threeCountTagWidth < maxWidthSize.width &&
@@ -257,10 +258,8 @@ class _BrnRangeSelectionGroupWidgetState
         tagWidth = fourCountTagWidth;
       }
     } else {
-      tagWidth = (_screenWidth -
-              40 -
-              12 * (widget.rowCount! - 1)) ~/
-          widget.rowCount!;
+      tagWidth =
+          (_screenWidth - 40 - 12 * (widget.rowCount! - 1)) ~/ widget.rowCount!;
     }
 
     var tagContainer = tagFilterList.isNotEmpty
@@ -435,12 +434,15 @@ class _BrnRangeSelectionGroupWidgetState
         if (!rangeEntity.isValidRange()) {
           FocusScope.of(context).requestFocus(FocusNode());
           if (rangeEntity.filterType == BrnSelectionFilterType.range) {
-            BrnToast.show(BrnIntl.of(context).localizedResource.enterRangeError, context);
+            BrnToast.show(
+                BrnIntl.of(context).localizedResource.enterRangeError, context);
           } else if (rangeEntity.filterType ==
                   BrnSelectionFilterType.dateRange ||
               rangeEntity.filterType ==
                   BrnSelectionFilterType.dateRangeCalendar) {
-            BrnToast.show(BrnIntl.of(context).localizedResource.selectRangeError, context);
+            BrnToast.show(
+                BrnIntl.of(context).localizedResource.selectRangeError,
+                context);
           }
           return;
         }
@@ -664,10 +666,11 @@ class _BrnRangeSelectionGroupWidgetState
   bool _hasCalendarItem(BrnSelectionEntity entity) {
     bool hasCalendarItem = false;
     hasCalendarItem = entity.children
-            .where((_) =>
-                _.filterType == BrnSelectionFilterType.date ||
-                _.filterType == BrnSelectionFilterType.dateRangeCalendar)
-            .toList().isNotEmpty;
+        .where((_) =>
+            _.filterType == BrnSelectionFilterType.date ||
+            _.filterType == BrnSelectionFilterType.dateRangeCalendar)
+        .toList()
+        .isNotEmpty;
 
     /// 查找第二层级
     if (!hasCalendarItem) {


### PR DESCRIPTION
_BrnRangeSelectionGroupWidgetState 类的一个问题：
在 initState() 方法中调用 View.of(context)，导致 Flutter 抛出如下错误：
dependOnInheritedWidgetOfExactType<_ViewScope>() or dependOnInheritedElement() was called before initState() completed.

问题原因
Flutter 框架禁止在 initState() 中调用依赖 InheritedWidget 的方法
因为此时组件尚未完成构建树插入，无法正确注册依赖

解决方案
将 View.of(context) 相关调用从 initState() 中移至 didChangeDependencies() 方法中，
该方法在组件插入构建树后调用，能安全访问 context 和依赖的 InheritedWidget

